### PR TITLE
adds javascript to add tooltips to edit buttons

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
 
   <!-- Plugin-specific properties -->
   <property name="pluginKey" value="EC-DSLIDE" />
-  <property name="pluginVersion" value="1.4.3" />
+  <property name="pluginVersion" value="1.4.4" />
   <!-- 
 	1.4.3 - Fix issue with Flow menu, failing if menu not present
 	1.4.2 - Add to Flow menu

--- a/htdocs/dslide.js
+++ b/htdocs/dslide.js
@@ -329,4 +329,12 @@ function insertSubprocedure() {
 		console.log( "project complete" );
 	  });
 }
+// adds tooltips to the edit buttons
+var editButtons = document.getElementById('editControls').getElementsByTagName('a');
+var numItems = editButtons.length;
 
+if (numItems > 0) {
+  for (var i = 0; i < numItems; i++) {
+    editButtons[i].title = editButtons[i].getAttribute('data-role');
+  }
+}


### PR DESCRIPTION
Inserted some logic at the end of the dslide.js file to look at the data-role attribute of the edit buttons and then insert a tooltip with that value.  The goal being to provide users with a little more guidance about what the buttons do.